### PR TITLE
fix: correct lamp colours / improve UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,383 +7,383 @@
   <body>
     <main>
       <!-- row 1: Live slots -->
-      <div title="Live track 1 (Fire Hydrant)" id="slot-fhyd-live" class="slot slot-live slot-fhyd"><span class="label">Fire Hydrant</span></div>
-      <div title="Live track 2 (Tangerine)" id="slot-tang-live" class="slot slot-live slot-tang"><span class="label">Tangerine</span></div>
-      <div title="Live track 3 (Durian)" id="slot-duri-live" class="slot slot-live slot-duri"><span class="label">Durian</span></div>
-      <div title="Live track 4 (Pomelo)" id="slot-poml-live" class="slot slot-live slot-poml"><span class="label">Pomelo</span></div>
-      <div title="Live track 5 (Tiffany)" id="slot-tiff-live" class="slot slot-live slot-tiff"><span class="label">Tiffany</span></div>
-      <div title="Live track 6 (Cosmic Cobalt)" id="slot-coco-live" class="slot slot-live slot-coco"><span class="label">Cosmic Cobalt</span></div>
-      <div title="Live track 7 (Plump)" id="slot-plum-live" class="slot slot-live slot-plum"><span class="label">Plump</span></div>
-      <div title="Live track 8 (Flamingo)" id="slot-flam-live" class="slot slot-live slot-flam"><span class="label">Flamingo</span></div>
+      <div title="Live track 1 (Fire Hydrant)" id="slot-fhyd-live" class="slot slot-live slot-fhyd"><span class="label">Fire Hydrant<span class="details">Channel 1</span></span></div>
+      <div title="Live track 2 (Tangerine)" id="slot-tang-live" class="slot slot-live slot-tang"><span class="label">Tangerine<span class="details">Channel 2</span></span></div>
+      <div title="Live track 3 (Durian)" id="slot-duri-live" class="slot slot-live slot-duri"><span class="label">Durian<span class="details">Channel 3</span></span></div>
+      <div title="Live track 4 (Pomelo)" id="slot-poml-live" class="slot slot-live slot-poml"><span class="label">Pomelo<span class="details">Channel 4</span></span></div>
+      <div title="Live track 5 (Tiffany)" id="slot-tiff-live" class="slot slot-live slot-tiff"><span class="label">Tiffany<span class="details">Channel 5</span></span></div>
+      <div title="Live track 6 (Cosmic Cobalt)" id="slot-coco-live" class="slot slot-live slot-coco"><span class="label">Cosmic Cobalt<span class="details">Channel 6</span></span></div>
+      <div title="Live track 7 (Plump)" id="slot-plum-live" class="slot slot-live slot-plum"><span class="label">Plump<span class="details">Channel 7</span></span></div>
+      <div title="Live track 8 (Flamingo)" id="slot-flam-live" class="slot slot-live slot-flam"><span class="label">Flamingo<span class="details">Channel 8</span></span></div>
       <!-- row 2: Live lamps -->
-      <div title="Note" id="lamp-fhyd-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-fhyd-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-fhyd-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-fhyd-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-tang-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-tang-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-tang-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-tang-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-duri-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-duri-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-duri-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-duri-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-poml-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-poml-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-poml-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-poml-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-tiff-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-tiff-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-tiff-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-tiff-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-coco-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-coco-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-coco-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-coco-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-plum-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-plum-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-plum-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-plum-live-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-flam-live-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-flam-live-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-flam-live-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-flam-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-fhyd-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-fhyd-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-fhyd-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-fhyd-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-tang-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-tang-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tang-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tang-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-duri-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-duri-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-duri-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-duri-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-poml-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-poml-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-poml-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-poml-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-tiff-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-tiff-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tiff-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tiff-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-coco-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-coco-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-coco-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-coco-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-plum-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-plum-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-plum-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-plum-live-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-flam-live-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-flam-live-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-flam-live-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-flam-live-pb" class="lamp lamp-pb"></div>
       <!-- row 3: Reason sketch 1 slots -->
-      <div title="Reason sketch 1 track 1 (Fire Hydrant)" id="slot-fhyd-reason-1" class="slot slot-reason slot-fhyd"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 2 (Tangerine)" id="slot-tang-reason-1" class="slot slot-reason slot-tang"><span class="label reason-label">Tangerine</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 3 (Durian)" id="slot-duri-reason-1" class="slot slot-reason slot-duri"><span class="label reason-label">Durian</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 4 (Pomelo)" id="slot-poml-reason-1" class="slot slot-reason slot-poml"><span class="label reason-label">Pomelo</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 5 (Tiffany)" id="slot-tiff-reason-1" class="slot slot-reason slot-tiff"><span class="label reason-label">Tiffany</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 6 (Cosmic Cobalt)" id="slot-coco-reason-1" class="slot slot-reason slot-coco"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 7 (Plump)" id="slot-plum-reason-1" class="slot slot-reason slot-plum"><span class="label reason-label">Plump</span><span class="sketch-number">1</span></div>
-      <div title="Reason sketch 1 track 7 (Flamingo)" id="slot-flam-reason-1" class="slot slot-reason slot-flam"><span class="label reason-label">Flamingo</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 1 (Fire Hydrant)" id="slot-fhyd-reason-1" class="slot slot-reason slot-fhyd"><span class="label reason-label">Fire Hydrant<span class="details">Bus A—Ch. 1</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 2 (Tangerine)" id="slot-tang-reason-1" class="slot slot-reason slot-tang"><span class="label reason-label">Tangerine<span class="details">Bus A—Ch. 2</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 3 (Durian)" id="slot-duri-reason-1" class="slot slot-reason slot-duri"><span class="label reason-label">Durian<span class="details">Bus A—Ch. 3</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 4 (Pomelo)" id="slot-poml-reason-1" class="slot slot-reason slot-poml"><span class="label reason-label">Pomelo<span class="details">Bus A—Ch. 4</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 5 (Tiffany)" id="slot-tiff-reason-1" class="slot slot-reason slot-tiff"><span class="label reason-label">Tiffany<span class="details">Bus A—Ch. 5</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 6 (Cosmic Cobalt)" id="slot-coco-reason-1" class="slot slot-reason slot-coco"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus A—Ch. 6</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 7 (Plump)" id="slot-plum-reason-1" class="slot slot-reason slot-plum"><span class="label reason-label">Plump<span class="details">Bus A—Ch. 7</span></span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 7 (Flamingo)" id="slot-flam-reason-1" class="slot slot-reason slot-flam"><span class="label reason-label">Flamingo<span class="details">Bus A—Ch. 8</span></span><span class="sketch-number">1</span></div>
       <!-- row 4: Reason sketch 1 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-fhyd-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-tang-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-tang-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-duri-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-duri-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-poml-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-poml-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-tiff-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-tiff-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-coco-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-coco-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-plum-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-plum-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-1-pb" class="lamp-pb"></div>
-      <div title="Note" id="lamp-flam-reason-1-note" class="lamp-note"></div>
-      <div title="Control change" id="lamp-flam-reason-1-cc" class="lamp-cc"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-1-at" class="lamp-at"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-fhyd-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-fhyd-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-tang-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-tang-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-duri-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-duri-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-poml-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-poml-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-tiff-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-tiff-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-coco-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-coco-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-plum-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-plum-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-1-pb" class="lamp lamp-pb"></div>
+      <div title="Note" id="lamp-flam-reason-1-note" class="lamp lamp-note"></div>
+      <div title="Control change" id="lamp-flam-reason-1-cc" class="lamp lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-1-at" class="lamp lamp-at"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-1-pb" class="lamp lamp-pb"></div>
       <!-- row 5: Reason sketch 2 slots -->
-      <div title="Reason sketch 2 track 1 (Fire Hydrant)" id="slot-fhyd-reason-2" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 2 (Tangerine)" id="slot-tang-reason-2" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 3 (Durian)" id="slot-duri-reason-2" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 4 (Pomelo)" id="slot-poml-reason-2" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 5 (Tiffany)" id="slot-tiff-reason-2" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 6 (Cosmic Cobalt)" id="slot-coco-reason-2" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 7 (Plump)" id="slot-plum-reason-2" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">2</span></div>
-      <div title="Reason sketch 2 track 7 (Flamingo)" id="slot-flam-reason-2" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 1 (Fire Hydrant)" id="slot-fhyd-reason-2" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus A—Ch. 9</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 2 (Tangerine)" id="slot-tang-reason-2" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus A—Ch. 10</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 3 (Durian)" id="slot-duri-reason-2" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus A—Ch. 11</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 4 (Pomelo)" id="slot-poml-reason-2" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus A—Ch. 12</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 5 (Tiffany)" id="slot-tiff-reason-2" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus A—Ch. 13</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 6 (Cosmic Cobalt)" id="slot-coco-reason-2" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus A—Ch. 14</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 7 (Plump)" id="slot-plum-reason-2" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus A—Ch. 15</span></span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 7 (Flamingo)" id="slot-flam-reason-2" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus A—Ch. 16</span></span><span class="sketch-number">2</span></div>
       <!-- row 6: Reason sketch 2 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-2-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-2-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-2-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-2-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-2-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-2-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-2-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-2-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-2-pb" class="lamp lamp-pb inactive"></div>
       <!-- row 7: Reason sketch 3 slots -->
-      <div title="Reason sketch 3 track 1 (Fire Hydrant)" id="slot-fhyd-reason-3" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 2 (Tangerine)" id="slot-tang-reason-3" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 3 (Durian)" id="slot-duri-reason-3" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 4 (Pomelo)" id="slot-poml-reason-3" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 5 (Tiffany)" id="slot-tiff-reason-3" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 6 (Cosmic Cobalt)" id="slot-coco-reason-3" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 7 (Plump)" id="slot-plum-reason-3" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">3</span></div>
-      <div title="Reason sketch 3 track 7 (Flamingo)" id="slot-flam-reason-3" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 1 (Fire Hydrant)" id="slot-fhyd-reason-3" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus B—Ch. 1</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 2 (Tangerine)" id="slot-tang-reason-3" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus B—Ch. 2</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 3 (Durian)" id="slot-duri-reason-3" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus B—Ch. 3</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 4 (Pomelo)" id="slot-poml-reason-3" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus B—Ch. 4</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 5 (Tiffany)" id="slot-tiff-reason-3" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus B—Ch. 5</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 6 (Cosmic Cobalt)" id="slot-coco-reason-3" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus B—Ch. 6</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 7 (Plump)" id="slot-plum-reason-3" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus B—Ch. 7</span></span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 7 (Flamingo)" id="slot-flam-reason-3" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus B—Ch. 8</span></span><span class="sketch-number">3</span></div>
       <!-- row 8: Reason sketch 3 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-3-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-3-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-3-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-3-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-3-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-3-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-3-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-3-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-3-pb" class="lamp lamp-pb inactive"></div>
       <!-- row 9: Reason sketch 4 slots -->
-      <div title="Reason sketch 4 track 1 (Fire Hydrant)" id="slot-fhyd-reason-4" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 2 (Tangerine)" id="slot-tang-reason-4" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 3 (Durian)" id="slot-duri-reason-4" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 4 (Pomelo)" id="slot-poml-reason-4" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 5 (Tiffany)" id="slot-tiff-reason-4" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 6 (Cosmic Cobalt)" id="slot-coco-reason-4" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 7 (Plump)" id="slot-plum-reason-4" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">4</span></div>
-      <div title="Reason sketch 4 track 7 (Flamingo)" id="slot-flam-reason-4" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 1 (Fire Hydrant)" id="slot-fhyd-reason-4" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus B—Ch. 9</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 2 (Tangerine)" id="slot-tang-reason-4" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus B—Ch. 10</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 3 (Durian)" id="slot-duri-reason-4" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus B—Ch. 11</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 4 (Pomelo)" id="slot-poml-reason-4" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus B—Ch. 12</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 5 (Tiffany)" id="slot-tiff-reason-4" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus B—Ch. 13</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 6 (Cosmic Cobalt)" id="slot-coco-reason-4" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus B—Ch. 14</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 7 (Plump)" id="slot-plum-reason-4" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus B—Ch. 15</span></span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 7 (Flamingo)" id="slot-flam-reason-4" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus B—Ch. 16</span></span><span class="sketch-number">4</span></div>
       <!-- row 10: Reason sketch 4 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-4-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-4-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-4-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-4-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-4-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-4-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-4-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-4-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-4-pb" class="lamp lamp-pb inactive"></div>
       <!-- row 11: Reason sketch 5 slots -->
-      <div title="Reason sketch 5 track 1 (Fire Hydrant)" id="slot-fhyd-reason-5" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 2 (Tangerine)" id="slot-tang-reason-5" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 3 (Durian)" id="slot-duri-reason-5" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 4 (Pomelo)" id="slot-poml-reason-5" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 5 (Tiffany)" id="slot-tiff-reason-5" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 6 (Cosmic Cobalt)" id="slot-coco-reason-5" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 7 (Plump)" id="slot-plum-reason-5" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">5</span></div>
-      <div title="Reason sketch 5 track 7 (Flamingo)" id="slot-flam-reason-5" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 1 (Fire Hydrant)" id="slot-fhyd-reason-5" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus C—Ch. 1</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 2 (Tangerine)" id="slot-tang-reason-5" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus C—Ch. 2</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 3 (Durian)" id="slot-duri-reason-5" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus C—Ch. 3</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 4 (Pomelo)" id="slot-poml-reason-5" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus C—Ch. 4</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 5 (Tiffany)" id="slot-tiff-reason-5" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus C—Ch. 5</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 6 (Cosmic Cobalt)" id="slot-coco-reason-5" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus C—Ch. 6</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 7 (Plump)" id="slot-plum-reason-5" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus C—Ch. 7</span></span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 7 (Flamingo)" id="slot-flam-reason-5" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus C—Ch. 8</span></span><span class="sketch-number">5</span></div>
       <!-- row 12: Reason sketch 5 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-5-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-5-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-5-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-5-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-5-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-5-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-5-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-5-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-5-pb" class="lamp lamp-pb inactive"></div>
       <!-- row 13: Reason sketch 6 slots -->
-      <div title="Reason sketch 6 track 1 (Fire Hydrant)" id="slot-fhyd-reason-6" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 2 (Tangerine)" id="slot-tang-reason-6" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 3 (Durian)" id="slot-duri-reason-6" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 4 (Pomelo)" id="slot-poml-reason-6" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 5 (Tiffany)" id="slot-tiff-reason-6" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 6 (Cosmic Cobalt)" id="slot-coco-reason-6" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 7 (Plump)" id="slot-plum-reason-6" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">6</span></div>
-      <div title="Reason sketch 6 track 7 (Flamingo)" id="slot-flam-reason-6" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 1 (Fire Hydrant)" id="slot-fhyd-reason-6" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus C—Ch. 9</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 2 (Tangerine)" id="slot-tang-reason-6" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus C—Ch. 10</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 3 (Durian)" id="slot-duri-reason-6" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus C—Ch. 11</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 4 (Pomelo)" id="slot-poml-reason-6" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus C—Ch. 12</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 5 (Tiffany)" id="slot-tiff-reason-6" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus C—Ch. 13</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 6 (Cosmic Cobalt)" id="slot-coco-reason-6" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus C—Ch. 14</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 7 (Plump)" id="slot-plum-reason-6" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus C—Ch. 15</span></span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 7 (Flamingo)" id="slot-flam-reason-6" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus C—Ch. 16</span></span><span class="sketch-number">6</span></div>
       <!-- row 14: Reason sketch 6 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-6-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-6-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-6-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-6-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-6-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-6-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-6-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-6-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-6-pb" class="lamp lamp-pb inactive"></div>
       <!-- row 15: Reason sketch 7 slots -->
-      <div title="Reason sketch 7 track 1 (Fire Hydrant)" id="slot-fhyd-reason-7" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 2 (Tangerine)" id="slot-tang-reason-7" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 3 (Durian)" id="slot-duri-reason-7" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 4 (Pomelo)" id="slot-poml-reason-7" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 5 (Tiffany)" id="slot-tiff-reason-7" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 6 (Cosmic Cobalt)" id="slot-coco-reason-7" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 7 (Plump)" id="slot-plum-reason-7" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">7</span></div>
-      <div title="Reason sketch 7 track 7 (Flamingo)" id="slot-flam-reason-7" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 1 (Fire Hydrant)" id="slot-fhyd-reason-7" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus D—Ch. 1</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 2 (Tangerine)" id="slot-tang-reason-7" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus D—Ch. 2</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 3 (Durian)" id="slot-duri-reason-7" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus D—Ch. 3</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 4 (Pomelo)" id="slot-poml-reason-7" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus D—Ch. 4</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 5 (Tiffany)" id="slot-tiff-reason-7" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus D—Ch. 5</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 6 (Cosmic Cobalt)" id="slot-coco-reason-7" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus D—Ch. 6</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 7 (Plump)" id="slot-plum-reason-7" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus D—Ch. 7</span></span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 7 (Flamingo)" id="slot-flam-reason-7" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus D—Ch. 8</span></span><span class="sketch-number">7</span></div>
       <!-- row 16: Reason sketch 7 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-7-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-7-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-7-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-7-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-7-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-7-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-7-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-7-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-7-cc" class="lamp lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-7-at" class="lamp lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-7-pb" class="lamp lamp-pb inactive"></div>
       <!-- row 17: Reason sketch 8 slots -->
-      <div title="Reason sketch 8 track 1 (Fire Hydrant)" id="slot-fhyd-reason-8" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 2 (Tangerine)" id="slot-tang-reason-8" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 3 (Durian)" id="slot-duri-reason-8" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 4 (Pomelo)" id="slot-poml-reason-8" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 5 (Tiffany)" id="slot-tiff-reason-8" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 6 (Cosmic Cobalt)" id="slot-coco-reason-8" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 7 (Plump)" id="slot-plum-reason-8" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">8</span></div>
-      <div title="Reason sketch 8 track 7 (Flamingo)" id="slot-flam-reason-8" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 1 (Fire Hydrant)" id="slot-fhyd-reason-8" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant<span class="details">Bus D—Ch. 9</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 2 (Tangerine)" id="slot-tang-reason-8" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine<span class="details">Bus D—Ch. 10</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 3 (Durian)" id="slot-duri-reason-8" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian<span class="details">Bus D—Ch. 11</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 4 (Pomelo)" id="slot-poml-reason-8" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo<span class="details">Bus D—Ch. 12</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 5 (Tiffany)" id="slot-tiff-reason-8" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany<span class="details">Bus D—Ch. 13</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 6 (Cosmic Cobalt)" id="slot-coco-reason-8" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt<span class="details">Bus D—Ch. 14</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 7 (Plump)" id="slot-plum-reason-8" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump<span class="details">Bus D—Ch. 15</span></span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 7 (Flamingo)" id="slot-flam-reason-8" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo<span class="details">Bus D—Ch. 16</span></span><span class="sketch-number">8</span></div>
       <!-- row 18: Reason sketch 8 lamps -->
-      <div title="Note" id="lamp-fhyd-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-fhyd-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-fhyd-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-fhyd-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tang-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tang-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tang-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tang-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-duri-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-duri-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-duri-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-duri-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-poml-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-poml-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-poml-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-poml-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-tiff-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-tiff-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-tiff-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-tiff-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-coco-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-coco-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-coco-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-coco-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-plum-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-plum-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-plum-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-plum-reason-8-pb" class="lamp-pb inactive"></div>
-      <div title="Note" id="lamp-flam-reason-8-note" class="lamp-note inactive"></div>
-      <div title="Control change" id="lamp-flam-reason-8-cc" class="lamp-cc inactive"></div>
-      <div title="Aftertouch" id="lamp-flam-reason-8-at" class="lamp-at inactive"></div>
-      <div title="Pitch bend" id="lamp-flam-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-8-pb" class="lamp lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-8-note" class="lamp lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-8-cc" class="lamp lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-8-at" class="lamp lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-8-pb" class="lamp lamp-pb inactive"></div>
       <script type="module" src="./src/renderer.ts"></script>
     </main>
   </body>

--- a/index.html
+++ b/index.html
@@ -7,383 +7,383 @@
   <body>
     <main>
       <!-- row 1: Live slots -->
-      <div id="slot-fhyd-live" class="slot slot-live slot-fhyd"><span class="label">Fire Hydrant</span></div>
-      <div id="slot-tang-live" class="slot slot-live slot-tang"><span class="label">Tangerine</span></div>
-      <div id="slot-duri-live" class="slot slot-live slot-duri"><span class="label">Durian</span></div>
-      <div id="slot-poml-live" class="slot slot-live slot-poml"><span class="label">Pomelo</span></div>
-      <div id="slot-tiff-live" class="slot slot-live slot-tiff"><span class="label">Tiffany</span></div>
-      <div id="slot-coco-live" class="slot slot-live slot-coco"><span class="label">Cosmic Cobalt</span></div>
-      <div id="slot-plum-live" class="slot slot-live slot-plum"><span class="label">Plump</span></div>
-      <div id="slot-flam-live" class="slot slot-live slot-flam"><span class="label">Flamingo</span></div>
+      <div title="Live track 1 (Fire Hydrant)" id="slot-fhyd-live" class="slot slot-live slot-fhyd"><span class="label">Fire Hydrant</span></div>
+      <div title="Live track 2 (Tangerine)" id="slot-tang-live" class="slot slot-live slot-tang"><span class="label">Tangerine</span></div>
+      <div title="Live track 3 (Durian)" id="slot-duri-live" class="slot slot-live slot-duri"><span class="label">Durian</span></div>
+      <div title="Live track 4 (Pomelo)" id="slot-poml-live" class="slot slot-live slot-poml"><span class="label">Pomelo</span></div>
+      <div title="Live track 5 (Tiffany)" id="slot-tiff-live" class="slot slot-live slot-tiff"><span class="label">Tiffany</span></div>
+      <div title="Live track 6 (Cosmic Cobalt)" id="slot-coco-live" class="slot slot-live slot-coco"><span class="label">Cosmic Cobalt</span></div>
+      <div title="Live track 7 (Plump)" id="slot-plum-live" class="slot slot-live slot-plum"><span class="label">Plump</span></div>
+      <div title="Live track 8 (Flamingo)" id="slot-flam-live" class="slot slot-live slot-flam"><span class="label">Flamingo</span></div>
       <!-- row 2: Live lamps -->
-      <div id="lamp-fhyd-live-note" class="lamp-note"></div>
-      <div id="lamp-fhyd-live-cc" class="lamp-cc"></div>
-      <div id="lamp-fhyd-live-at" class="lamp-at"></div>
-      <div id="lamp-fhyd-live-pb" class="lamp-pb"></div>
-      <div id="lamp-tang-live-note" class="lamp-note"></div>
-      <div id="lamp-tang-live-cc" class="lamp-cc"></div>
-      <div id="lamp-tang-live-at" class="lamp-at"></div>
-      <div id="lamp-tang-live-pb" class="lamp-pb"></div>
-      <div id="lamp-duri-live-note" class="lamp-note"></div>
-      <div id="lamp-duri-live-cc" class="lamp-cc"></div>
-      <div id="lamp-duri-live-at" class="lamp-at"></div>
-      <div id="lamp-duri-live-pb" class="lamp-pb"></div>
-      <div id="lamp-poml-live-note" class="lamp-note"></div>
-      <div id="lamp-poml-live-cc" class="lamp-cc"></div>
-      <div id="lamp-poml-live-at" class="lamp-at"></div>
-      <div id="lamp-poml-live-pb" class="lamp-pb"></div>
-      <div id="lamp-tiff-live-note" class="lamp-note"></div>
-      <div id="lamp-tiff-live-cc" class="lamp-cc"></div>
-      <div id="lamp-tiff-live-at" class="lamp-at"></div>
-      <div id="lamp-tiff-live-pb" class="lamp-pb"></div>
-      <div id="lamp-coco-live-note" class="lamp-note"></div>
-      <div id="lamp-coco-live-cc" class="lamp-cc"></div>
-      <div id="lamp-coco-live-at" class="lamp-at"></div>
-      <div id="lamp-coco-live-pb" class="lamp-pb"></div>
-      <div id="lamp-plum-live-note" class="lamp-note"></div>
-      <div id="lamp-plum-live-cc" class="lamp-cc"></div>
-      <div id="lamp-plum-live-at" class="lamp-at"></div>
-      <div id="lamp-plum-live-pb" class="lamp-pb"></div>
-      <div id="lamp-flam-live-note" class="lamp-note"></div>
-      <div id="lamp-flam-live-cc" class="lamp-cc"></div>
-      <div id="lamp-flam-live-at" class="lamp-at"></div>
-      <div id="lamp-flam-live-pb" class="lamp-pb"></div>
-      <!-- row 3: Reason 1 slots -->
-      <div id="slot-fhyd-reason-1" class="slot slot-reason slot-fhyd"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">1</span></div>
-      <div id="slot-tang-reason-1" class="slot slot-reason slot-tang"><span class="label reason-label">Tangerine</span><span class="sketch-number">1</span></div>
-      <div id="slot-duri-reason-1" class="slot slot-reason slot-duri"><span class="label reason-label">Durian</span><span class="sketch-number">1</span></div>
-      <div id="slot-poml-reason-1" class="slot slot-reason slot-poml"><span class="label reason-label">Pomelo</span><span class="sketch-number">1</span></div>
-      <div id="slot-tiff-reason-1" class="slot slot-reason slot-tiff"><span class="label reason-label">Tiffany</span><span class="sketch-number">1</span></div>
-      <div id="slot-coco-reason-1" class="slot slot-reason slot-coco"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">1</span></div>
-      <div id="slot-plum-reason-1" class="slot slot-reason slot-plum"><span class="label reason-label">Plump</span><span class="sketch-number">1</span></div>
-      <div id="slot-flam-reason-1" class="slot slot-reason slot-flam"><span class="label reason-label">Flamingo</span><span class="sketch-number">1</span></div>
-      <!-- row 4: Reason 1 lamps -->
-      <div id="lamp-fhyd-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-fhyd-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-fhyd-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-fhyd-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-tang-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-tang-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-tang-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-tang-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-duri-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-duri-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-duri-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-duri-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-poml-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-poml-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-poml-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-poml-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-tiff-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-tiff-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-tiff-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-tiff-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-coco-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-coco-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-coco-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-coco-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-plum-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-plum-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-plum-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-plum-reason-1-pb" class="lamp-pb"></div>
-      <div id="lamp-flam-reason-1-note" class="lamp-note"></div>
-      <div id="lamp-flam-reason-1-cc" class="lamp-cc"></div>
-      <div id="lamp-flam-reason-1-at" class="lamp-at"></div>
-      <div id="lamp-flam-reason-1-pb" class="lamp-pb"></div>
-      <!-- row 5: Reason 2 slots -->
-      <div id="slot-fhyd-reason-2" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">2</span></div>
-      <div id="slot-tang-reason-2" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">2</span></div>
-      <div id="slot-duri-reason-2" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">2</span></div>
-      <div id="slot-poml-reason-2" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">2</span></div>
-      <div id="slot-tiff-reason-2" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">2</span></div>
-      <div id="slot-coco-reason-2" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">2</span></div>
-      <div id="slot-plum-reason-2" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">2</span></div>
-      <div id="slot-flam-reason-2" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">2</span></div>
-      <!-- row 6: Reason 2 lamps -->
-      <div id="lamp-fhyd-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-2-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-2-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-2-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-2-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-2-pb" class="lamp-pb inactive"></div>
-      <!-- row 7: Reason 3 slots -->
-      <div id="slot-fhyd-reason-3" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">3</span></div>
-      <div id="slot-tang-reason-3" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">3</span></div>
-      <div id="slot-duri-reason-3" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">3</span></div>
-      <div id="slot-poml-reason-3" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">3</span></div>
-      <div id="slot-tiff-reason-3" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">3</span></div>
-      <div id="slot-coco-reason-3" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">3</span></div>
-      <div id="slot-plum-reason-3" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">3</span></div>
-      <div id="slot-flam-reason-3" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">3</span></div>
-      <!-- row 8: Reason 3 lamps -->
-      <div id="lamp-fhyd-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-3-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-3-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-3-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-3-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-3-pb" class="lamp-pb inactive"></div>
-      <!-- row 9: Reason 4 slots -->
-      <div id="slot-fhyd-reason-4" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">4</span></div>
-      <div id="slot-tang-reason-4" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">4</span></div>
-      <div id="slot-duri-reason-4" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">4</span></div>
-      <div id="slot-poml-reason-4" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">4</span></div>
-      <div id="slot-tiff-reason-4" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">4</span></div>
-      <div id="slot-coco-reason-4" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">4</span></div>
-      <div id="slot-plum-reason-4" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">4</span></div>
-      <div id="slot-flam-reason-4" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">4</span></div>
-      <!-- row 10: Reason 4 lamps -->
-      <div id="lamp-fhyd-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-4-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-4-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-4-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-4-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-4-pb" class="lamp-pb inactive"></div>
-      <!-- row 11: Reason 5 slots -->
-      <div id="slot-fhyd-reason-5" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">5</span></div>
-      <div id="slot-tang-reason-5" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">5</span></div>
-      <div id="slot-duri-reason-5" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">5</span></div>
-      <div id="slot-poml-reason-5" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">5</span></div>
-      <div id="slot-tiff-reason-5" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">5</span></div>
-      <div id="slot-coco-reason-5" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">5</span></div>
-      <div id="slot-plum-reason-5" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">5</span></div>
-      <div id="slot-flam-reason-5" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">5</span></div>
-      <!-- row 12: Reason 5 lamps -->
-      <div id="lamp-fhyd-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-5-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-5-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-5-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-5-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-5-pb" class="lamp-pb inactive"></div>
-      <!-- row 13: Reason 6 slots -->
-      <div id="slot-fhyd-reason-6" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">6</span></div>
-      <div id="slot-tang-reason-6" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">6</span></div>
-      <div id="slot-duri-reason-6" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">6</span></div>
-      <div id="slot-poml-reason-6" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">6</span></div>
-      <div id="slot-tiff-reason-6" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">6</span></div>
-      <div id="slot-coco-reason-6" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">6</span></div>
-      <div id="slot-plum-reason-6" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">6</span></div>
-      <div id="slot-flam-reason-6" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">6</span></div>
-      <!-- row 14: Reason 6 lamps -->
-      <div id="lamp-fhyd-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-6-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-6-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-6-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-6-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-6-pb" class="lamp-pb inactive"></div>
-      <!-- row 15: Reason 7 slots -->
-      <div id="slot-fhyd-reason-7" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">7</span></div>
-      <div id="slot-tang-reason-7" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">7</span></div>
-      <div id="slot-duri-reason-7" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">7</span></div>
-      <div id="slot-poml-reason-7" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">7</span></div>
-      <div id="slot-tiff-reason-7" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">7</span></div>
-      <div id="slot-coco-reason-7" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">7</span></div>
-      <div id="slot-plum-reason-7" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">7</span></div>
-      <div id="slot-flam-reason-7" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">7</span></div>
-      <!-- row 16: Reason 7 lamps -->
-      <div id="lamp-fhyd-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-7-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-7-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-7-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-7-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-7-pb" class="lamp-pb inactive"></div>
-      <!-- row 17: Reason 8 slots -->
-      <div id="slot-fhyd-reason-8" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">8</span></div>
-      <div id="slot-tang-reason-8" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">8</span></div>
-      <div id="slot-duri-reason-8" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">8</span></div>
-      <div id="slot-poml-reason-8" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">8</span></div>
-      <div id="slot-tiff-reason-8" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">8</span></div>
-      <div id="slot-coco-reason-8" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">8</span></div>
-      <div id="slot-plum-reason-8" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">8</span></div>
-      <div id="slot-flam-reason-8" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">8</span></div>
-      <!-- row 18: Reason 8 lamps -->
-      <div id="lamp-fhyd-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-fhyd-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-fhyd-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-fhyd-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tang-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-tang-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tang-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-tang-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-duri-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-duri-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-duri-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-duri-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-poml-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-poml-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-poml-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-poml-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-tiff-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-tiff-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-tiff-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-tiff-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-coco-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-coco-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-coco-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-coco-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-plum-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-plum-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-plum-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-plum-reason-8-pb" class="lamp-pb inactive"></div>
-      <div id="lamp-flam-reason-8-note" class="lamp-note inactive"></div>
-      <div id="lamp-flam-reason-8-cc" class="lamp-cc inactive"></div>
-      <div id="lamp-flam-reason-8-at" class="lamp-at inactive"></div>
-      <div id="lamp-flam-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-fhyd-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-fhyd-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-fhyd-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-fhyd-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-tang-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-tang-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tang-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tang-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-duri-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-duri-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-duri-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-duri-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-poml-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-poml-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-poml-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-poml-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-tiff-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-tiff-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tiff-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tiff-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-coco-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-coco-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-coco-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-coco-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-plum-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-plum-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-plum-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-plum-live-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-flam-live-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-flam-live-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-flam-live-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-flam-live-pb" class="lamp-pb"></div>
+      <!-- row 3: Reason sketch 1 slots -->
+      <div title="Reason sketch 1 track 1 (Fire Hydrant)" id="slot-fhyd-reason-1" class="slot slot-reason slot-fhyd"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 2 (Tangerine)" id="slot-tang-reason-1" class="slot slot-reason slot-tang"><span class="label reason-label">Tangerine</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 3 (Durian)" id="slot-duri-reason-1" class="slot slot-reason slot-duri"><span class="label reason-label">Durian</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 4 (Pomelo)" id="slot-poml-reason-1" class="slot slot-reason slot-poml"><span class="label reason-label">Pomelo</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 5 (Tiffany)" id="slot-tiff-reason-1" class="slot slot-reason slot-tiff"><span class="label reason-label">Tiffany</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 6 (Cosmic Cobalt)" id="slot-coco-reason-1" class="slot slot-reason slot-coco"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 7 (Plump)" id="slot-plum-reason-1" class="slot slot-reason slot-plum"><span class="label reason-label">Plump</span><span class="sketch-number">1</span></div>
+      <div title="Reason sketch 1 track 7 (Flamingo)" id="slot-flam-reason-1" class="slot slot-reason slot-flam"><span class="label reason-label">Flamingo</span><span class="sketch-number">1</span></div>
+      <!-- row 4: Reason sketch 1 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-fhyd-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-tang-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-tang-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-duri-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-duri-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-poml-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-poml-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-tiff-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-tiff-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-coco-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-coco-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-plum-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-plum-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-1-pb" class="lamp-pb"></div>
+      <div title="Note" id="lamp-flam-reason-1-note" class="lamp-note"></div>
+      <div title="Control change" id="lamp-flam-reason-1-cc" class="lamp-cc"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-1-at" class="lamp-at"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-1-pb" class="lamp-pb"></div>
+      <!-- row 5: Reason sketch 2 slots -->
+      <div title="Reason sketch 2 track 1 (Fire Hydrant)" id="slot-fhyd-reason-2" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 2 (Tangerine)" id="slot-tang-reason-2" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 3 (Durian)" id="slot-duri-reason-2" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 4 (Pomelo)" id="slot-poml-reason-2" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 5 (Tiffany)" id="slot-tiff-reason-2" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 6 (Cosmic Cobalt)" id="slot-coco-reason-2" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 7 (Plump)" id="slot-plum-reason-2" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">2</span></div>
+      <div title="Reason sketch 2 track 7 (Flamingo)" id="slot-flam-reason-2" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">2</span></div>
+      <!-- row 6: Reason sketch 2 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-2-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-2-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-2-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-2-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-2-pb" class="lamp-pb inactive"></div>
+      <!-- row 7: Reason sketch 3 slots -->
+      <div title="Reason sketch 3 track 1 (Fire Hydrant)" id="slot-fhyd-reason-3" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 2 (Tangerine)" id="slot-tang-reason-3" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 3 (Durian)" id="slot-duri-reason-3" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 4 (Pomelo)" id="slot-poml-reason-3" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 5 (Tiffany)" id="slot-tiff-reason-3" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 6 (Cosmic Cobalt)" id="slot-coco-reason-3" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 7 (Plump)" id="slot-plum-reason-3" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">3</span></div>
+      <div title="Reason sketch 3 track 7 (Flamingo)" id="slot-flam-reason-3" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">3</span></div>
+      <!-- row 8: Reason sketch 3 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-3-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-3-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-3-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-3-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-3-pb" class="lamp-pb inactive"></div>
+      <!-- row 9: Reason sketch 4 slots -->
+      <div title="Reason sketch 4 track 1 (Fire Hydrant)" id="slot-fhyd-reason-4" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 2 (Tangerine)" id="slot-tang-reason-4" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 3 (Durian)" id="slot-duri-reason-4" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 4 (Pomelo)" id="slot-poml-reason-4" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 5 (Tiffany)" id="slot-tiff-reason-4" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 6 (Cosmic Cobalt)" id="slot-coco-reason-4" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 7 (Plump)" id="slot-plum-reason-4" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">4</span></div>
+      <div title="Reason sketch 4 track 7 (Flamingo)" id="slot-flam-reason-4" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">4</span></div>
+      <!-- row 10: Reason sketch 4 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-4-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-4-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-4-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-4-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-4-pb" class="lamp-pb inactive"></div>
+      <!-- row 11: Reason sketch 5 slots -->
+      <div title="Reason sketch 5 track 1 (Fire Hydrant)" id="slot-fhyd-reason-5" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 2 (Tangerine)" id="slot-tang-reason-5" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 3 (Durian)" id="slot-duri-reason-5" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 4 (Pomelo)" id="slot-poml-reason-5" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 5 (Tiffany)" id="slot-tiff-reason-5" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 6 (Cosmic Cobalt)" id="slot-coco-reason-5" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 7 (Plump)" id="slot-plum-reason-5" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">5</span></div>
+      <div title="Reason sketch 5 track 7 (Flamingo)" id="slot-flam-reason-5" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">5</span></div>
+      <!-- row 12: Reason sketch 5 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-5-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-5-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-5-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-5-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-5-pb" class="lamp-pb inactive"></div>
+      <!-- row 13: Reason sketch 6 slots -->
+      <div title="Reason sketch 6 track 1 (Fire Hydrant)" id="slot-fhyd-reason-6" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 2 (Tangerine)" id="slot-tang-reason-6" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 3 (Durian)" id="slot-duri-reason-6" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 4 (Pomelo)" id="slot-poml-reason-6" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 5 (Tiffany)" id="slot-tiff-reason-6" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 6 (Cosmic Cobalt)" id="slot-coco-reason-6" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 7 (Plump)" id="slot-plum-reason-6" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">6</span></div>
+      <div title="Reason sketch 6 track 7 (Flamingo)" id="slot-flam-reason-6" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">6</span></div>
+      <!-- row 14: Reason sketch 6 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-6-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-6-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-6-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-6-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-6-pb" class="lamp-pb inactive"></div>
+      <!-- row 15: Reason sketch 7 slots -->
+      <div title="Reason sketch 7 track 1 (Fire Hydrant)" id="slot-fhyd-reason-7" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 2 (Tangerine)" id="slot-tang-reason-7" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 3 (Durian)" id="slot-duri-reason-7" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 4 (Pomelo)" id="slot-poml-reason-7" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 5 (Tiffany)" id="slot-tiff-reason-7" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 6 (Cosmic Cobalt)" id="slot-coco-reason-7" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 7 (Plump)" id="slot-plum-reason-7" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">7</span></div>
+      <div title="Reason sketch 7 track 7 (Flamingo)" id="slot-flam-reason-7" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">7</span></div>
+      <!-- row 16: Reason sketch 7 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-7-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-7-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-7-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-7-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-7-pb" class="lamp-pb inactive"></div>
+      <!-- row 17: Reason sketch 8 slots -->
+      <div title="Reason sketch 8 track 1 (Fire Hydrant)" id="slot-fhyd-reason-8" class="slot slot-reason slot-fhyd inactive"><span class="label reason-label">Fire Hydrant</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 2 (Tangerine)" id="slot-tang-reason-8" class="slot slot-reason slot-tang inactive"><span class="label reason-label">Tangerine</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 3 (Durian)" id="slot-duri-reason-8" class="slot slot-reason slot-duri inactive"><span class="label reason-label">Durian</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 4 (Pomelo)" id="slot-poml-reason-8" class="slot slot-reason slot-poml inactive"><span class="label reason-label">Pomelo</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 5 (Tiffany)" id="slot-tiff-reason-8" class="slot slot-reason slot-tiff inactive"><span class="label reason-label">Tiffany</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 6 (Cosmic Cobalt)" id="slot-coco-reason-8" class="slot slot-reason slot-coco inactive"><span class="label reason-label">Cosmic Cobalt</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 7 (Plump)" id="slot-plum-reason-8" class="slot slot-reason slot-plum inactive"><span class="label reason-label">Plump</span><span class="sketch-number">8</span></div>
+      <div title="Reason sketch 8 track 7 (Flamingo)" id="slot-flam-reason-8" class="slot slot-reason slot-flam inactive"><span class="label reason-label">Flamingo</span><span class="sketch-number">8</span></div>
+      <!-- row 18: Reason sketch 8 lamps -->
+      <div title="Note" id="lamp-fhyd-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-fhyd-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-fhyd-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-fhyd-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tang-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tang-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tang-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tang-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-duri-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-duri-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-duri-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-duri-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-poml-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-poml-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-poml-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-poml-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-tiff-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-tiff-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-tiff-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-tiff-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-coco-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-coco-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-coco-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-coco-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-plum-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-plum-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-plum-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-plum-reason-8-pb" class="lamp-pb inactive"></div>
+      <div title="Note" id="lamp-flam-reason-8-note" class="lamp-note inactive"></div>
+      <div title="Control change" id="lamp-flam-reason-8-cc" class="lamp-cc inactive"></div>
+      <div title="Aftertouch" id="lamp-flam-reason-8-at" class="lamp-at inactive"></div>
+      <div title="Pitch bend" id="lamp-flam-reason-8-pb" class="lamp-pb inactive"></div>
       <script type="module" src="./src/renderer.ts"></script>
     </main>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "8tlr-router-desktop",
   "productName": "Eight Track LR Router",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Routes MIDI messages from Ableton Live to Reason",
   "main": ".vite/build/main.js",
   "repository": {

--- a/src/frontend/createUpdater.ts
+++ b/src/frontend/createUpdater.ts
@@ -11,7 +11,7 @@ interface TimeoutHandler {
   flam: NodeJS.Timeout | null;
 }
 
-export function createUpdater(midiMessageType:MidiMessageType) {
+export function createUpdater(midiMessageType: MidiMessageType) {
   const timeoutHandler: TimeoutHandler = {
     fhyd: null,
     tang: null,
@@ -34,12 +34,12 @@ export function createUpdater(midiMessageType:MidiMessageType) {
     [
       document.getElementById(`lamp-${track}-live-${midiMessageType}`),
       document.getElementById(`lamp-${track}-reason-${sketch}-${midiMessageType}`),
-    ].forEach((element) => element.classList.add("lamp-note-lit"));
+    ].forEach((element) => element.classList.add(`lamp-${midiMessageType}-lit`));
     timeoutHandler[track] = setTimeout(() => {
       [
         document.getElementById(`lamp-${track}-live-${midiMessageType}`),
         document.getElementById(`lamp-${track}-reason-${sketch}-${midiMessageType}`),
-      ].forEach((element) => element.classList.remove("lamp-note-lit"));
+      ].forEach((element) => element.classList.remove(`lamp-${midiMessageType}-lit`));
       timeoutHandler[track] = null;
     }, frontendUpdateInterval);
   };

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,8 @@ main {
 }
 
 .slot {
+  cursor: default;
+  user-select: none;
   background-repeat: no-repeat;
   background-position-x: left;
   background-position-y: center;

--- a/src/index.css
+++ b/src/index.css
@@ -84,14 +84,50 @@ main {
   color: white;
   white-space: nowrap;
   text-shadow:
-    -1px -1px 0 #000,
-    1px -1px 0 #000,
-    -1px 1px 0 #000,
-    1px 1px 0 #000;
+    0px 0px 5px #000000,
+    0px 0px 5px #000000;
 }
 
 .reason-label {
   margin-right: 0.2em;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.details {
+  display: block;
+  font-family: YanoneKaffeesatz-Light, sans-serif;
+  font-size: 0.7em;
+  text-align: center;
+}
+
+@media (max-height: 399px) {
+  .lamp {
+    border: none !important;
+  }
+  .details {
+    display: none;
+  }
+  .sketch-number,
+  .label {
+    font-size: 0.5em !important;
+  }
+}
+
+@media (min-height: 400px) and (max-height: 600px) {
+  .lamp {
+    border: none !important;
+  }
+  .details {
+    display: none;
+  }
+  .sketch-number {
+    font-size: 1em !important;
+  }
 }
 
 @media (max-width: 799px) {
@@ -107,6 +143,9 @@ main {
   .label {
     display: none;
   }
+  .details {
+    display: none;
+  }
 }
 
 @media (min-width: 800px) and (max-width: 1199px) {
@@ -116,6 +155,9 @@ main {
   }
   .sketch-number {
     font-size: 1.7em;
+  }
+  .details {
+    display: none;
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,8 @@ const createWindow = async () => {
     title: "Eight Track LR Router",
     width: 800,
     height: 600,
+    minWidth: 400,
+    minHeight: 300,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
     },


### PR DESCRIPTION
Use correct colours for lamps (previously always note/green).

Always have arrow cursor, even when hovering over text.

Add tool tips to lamps and slots.

Add slot details.

Constrain minimum app window size.