### PR TITLE
feat: make controls global across sketches

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,51 @@ This is, unfortunately, a security measure by Apple that prevents apps downloade
 executed unless they are approved by Apple.
 
 See discussion here: https://discussions.apple.com/thread/253714860?sortBy=best
+
+## Development
+
+### Initial setup
+
+Clone this GitHub repository to your local file system.
+
+Make sure you have the Node.js version that is specifiedv in _.nvmrc_ installed.
+
+Make sure you have Yarn installed (run `corepack enable`).
+
+Install dependencies:
+
+```
+yarn
+```
+
+Set up a _8tlr-router.config.yaml_ as explained above in section [Configuration file](#configuration-file).
+
+### Running in local dev mode
+
+Run in local dev mode with this command:
+
+```
+yarn start
+```
+
+This project uses [debug](https://www.npmjs.com/package/debug) for logging debug messages. They can help you understand
+what's going on.
+
+To run with debug messages on:
+
+```
+DEBUG=* yarn start
+```
+
+To show only debug messages from the 8TLR Router program, not from third-party-packages:
+
+```
+DEBUG=8tlr-router:* yarn start
+```
+
+You can show debug messages only from a spefific logger. For example, to see only logs for control change messages that
+were sent out:
+
+```
+DEBUG=8tlr-router:midi:router:cc yarn start
+```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx .",
+    "lint": "eslint --ext .ts .",
     "test": "vitest"
   },
   "devDependencies": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,6 +17,7 @@ interface UiUpdate {
 interface MidiMessageRouterResult {
   outputPortIndex: number;
   outputMidiMessage: MidiMessage;
+  outputIsGlobal: boolean;
 }
 
 type MidiMessageRouter = (deltaTime: number, midiMessage: MidiMessage) => MidiMessageRouterResult | null;

--- a/src/midi/index.ts
+++ b/src/midi/index.ts
@@ -1,7 +1,7 @@
-export { createNoteHandler } from "./noteHandler";
+export { createMidiMessageDeduper } from "./midiMessageDeduper";
 export { createMidiMessageHandler } from "./midiMessageHandler";
 export { createMidiMessageRouter } from "./midiMessageRouter";
-export { createMidiMessageDeduper } from "./midiMessageDeduper";
+export { createNoteHandler } from "./noteHandler";
 export { getMidiChannel } from "./getMidiChannel";
 export { getMidiMessageType } from "./getMidiMessageType";
 export { getMidiMessageTypeName } from "./getMidiMessageTypeName";
@@ -10,6 +10,7 @@ export { getPortIndex } from "./getPortIndex";
 export { initPort } from "./initPort";
 export { isAfterTouch } from "./isAfterTouch";
 export { isControlChange } from "./isControlChange";
+export { isGlobal } from "./isGlobal";
 export { isNoteOff } from "./isNoteOff";
 export { isNoteOn } from "./isNoteOn";
 export { isPitchBend } from "./isPitchBend";

--- a/src/midi/isGlobal.ts
+++ b/src/midi/isGlobal.ts
@@ -1,0 +1,8 @@
+import type { MidiMessage } from "@julusian/midi";
+import { isAfterTouch, isControlChange, isPitchBend } from ".";
+
+// “global” MIDI messages are not routed to the currently active sketch,
+// but to all the sketches, affecting controls on each sketch's Combinator
+export function isGlobal(message: MidiMessage) {
+  return isAfterTouch(message) || isControlChange(message) || isPitchBend(message);
+}

--- a/src/midi/midiMessageHandler.ts
+++ b/src/midi/midiMessageHandler.ts
@@ -3,7 +3,7 @@ import type { MidiMessage } from "@julusian/midi";
 interface Args {
   midiMessageRouter: MidiMessageRouter;
   observeMessage: (midiMessage: MidiMessage, portIndex: number) => void;
-  uiUpdater: (midiMessage: MidiMessage, portIndex: number) => void;
+  uiUpdater: (midiMessage: MidiMessage, portIndex: number, isGlobal: boolean) => void;
   isDuplicate: (midiMessage: MidiMessage) => boolean;
 }
 
@@ -16,9 +16,11 @@ export function createMidiMessageHandler({ midiMessageRouter, observeMessage, ui
     if (routingResult === null) {
       return;
     }
-    const { outputPortIndex, outputMidiMessage } = routingResult;
+    const { outputPortIndex, outputMidiMessage, outputIsGlobal } = routingResult;
 
-    uiUpdater(outputMidiMessage, outputPortIndex);
-    observeMessage(outputMidiMessage, outputPortIndex);
+    uiUpdater(outputMidiMessage, outputPortIndex, outputIsGlobal);
+    if (!outputIsGlobal) {
+      observeMessage(outputMidiMessage, outputPortIndex);
+    }
   };
 }

--- a/src/midi/midiMessageRouter.test.ts
+++ b/src/midi/midiMessageRouter.test.ts
@@ -10,6 +10,8 @@ const outputs: Output[] = new Array(4).fill(null).map(() => new mockedMidi.Outpu
 
 const NOTE_ON_CH1_C2_V100: MidiMessage = [0x90, 0x30, 0x64];
 const NOTE_ON_CH9_C2_V100: MidiMessage = [0x98, 0x30, 0x64];
+const CC_71_CH1_V100: MidiMessage = [0xb0, 0x47, 0x64];
+const CC_71_CH9_V100: MidiMessage = [0xb8, 0x47, 0x64];
 const PROGRAM_CHANGE_2: MidiMessage = [0xc0, 0x01];
 const PROGRAM_CHANGE_3: MidiMessage = [0xc0, 0x02];
 
@@ -38,9 +40,41 @@ describe("The router function created by createMidiMessageRouter", () => {
       it("returns the correct result", () => {
         expect(result).toMatchInlineSnapshot(`
           {
+            "outputIsGlobal": false,
             "outputMidiMessage": [
               144,
               48,
+              100,
+            ],
+            "outputPortIndex": 0,
+          }
+        `);
+      });
+    });
+
+    describe("and it receives a global MIDI message", () => {
+      beforeEach(() => {
+        result = midiMessageRouter(0, CC_71_CH1_V100);
+      });
+
+      it("routes incoming MIDI messages to all the output ports", () => {
+        expect(outputs[0].sendMessage).toHaveBeenCalledWith(CC_71_CH1_V100);
+        expect(outputs[0].sendMessage).toHaveBeenCalledWith(CC_71_CH9_V100);
+        expect(outputs[1].sendMessage).toHaveBeenCalledWith(CC_71_CH1_V100);
+        expect(outputs[1].sendMessage).toHaveBeenCalledWith(CC_71_CH9_V100);
+        expect(outputs[2].sendMessage).toHaveBeenCalledWith(CC_71_CH1_V100);
+        expect(outputs[2].sendMessage).toHaveBeenCalledWith(CC_71_CH9_V100);
+        expect(outputs[3].sendMessage).toHaveBeenCalledWith(CC_71_CH1_V100);
+        expect(outputs[3].sendMessage).toHaveBeenCalledWith(CC_71_CH9_V100);
+      });
+
+      it("returns the correct result", () => {
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "outputIsGlobal": true,
+            "outputMidiMessage": [
+              176,
+              71,
               100,
             ],
             "outputPortIndex": 0,
@@ -79,6 +113,7 @@ describe("The router function created by createMidiMessageRouter", () => {
     it("returns the correct result", () => {
       expect(result).toMatchInlineSnapshot(`
         {
+          "outputIsGlobal": false,
           "outputMidiMessage": [
             200,
             1,
@@ -101,6 +136,7 @@ describe("The router function created by createMidiMessageRouter", () => {
       it("returns the correct result", () => {
         expect(result).toMatchInlineSnapshot(`
           {
+            "outputIsGlobal": false,
             "outputMidiMessage": [
               152,
               48,
@@ -124,6 +160,7 @@ describe("The router function created by createMidiMessageRouter", () => {
     it("returns the correct result", () => {
       expect(result).toMatchInlineSnapshot(`
         {
+          "outputIsGlobal": false,
           "outputMidiMessage": [
             192,
             2,
@@ -142,6 +179,7 @@ describe("The router function created by createMidiMessageRouter", () => {
       it("returns the correct result", () => {
         expect(result).toMatchInlineSnapshot(`
           {
+            "outputIsGlobal": false,
             "outputMidiMessage": [
               144,
               48,

--- a/src/midi/noteHandler.ts
+++ b/src/midi/noteHandler.ts
@@ -8,13 +8,11 @@ import { formatMidiMessage } from "../utils";
 
 const debug = createDebug("8tlr-router:midi:note-handler");
 
-// TODO: note updater needs to send a UiUpdate when it sends a note off!!!!111!!!
-
 interface Args {
   input: Input;
   outputs: Output[];
   isDuplicate: (midiMessage: MidiMessage) => boolean;
-  uiUpdater: (midiMessage: MidiMessage, portIndex: number) => void;
+  uiUpdater: (midiMessage: MidiMessage, portIndex: number, isGlobal: boolean) => void;
 }
 
 export function createNoteHandler({ input, outputs, isDuplicate, uiUpdater }: Args) {
@@ -37,7 +35,7 @@ export function createNoteHandler({ input, outputs, isDuplicate, uiUpdater }: Ar
         const noteOff: MidiMessage = [0x90 + channelIndex, noteIndex, 0x00];
         debug(`${" ".repeat(42)}>>> ${formatMidiMessage(noteOff, "pretty")} | port: ${outputIndex + 1}`);
         outputs[outputIndex].sendMessage(noteOff);
-        uiUpdater(noteOff, outputIndex);
+        uiUpdater(noteOff, outputIndex, false);
 
         // we are creating a MIDI message sent to the output
         // eventually, the router will receive this same MIDI message,

--- a/src/ui/createUiUpdater.ts
+++ b/src/ui/createUiUpdater.ts
@@ -5,7 +5,7 @@ import { getMidiMessageType } from "../midi";
 import { getSketch } from "./getSketch";
 
 export function createUiUpdater(browserWindow: BrowserWindow) {
-  return (midiMessage: MidiMessage, portIndex: number) => {
+  return (midiMessage: MidiMessage, portIndex: number, isGlobal: boolean) => {
     const type = getMidiMessageType(midiMessage);
     if (!type) {
       // we only update the UI for note, control change, aftertouch (poly and channel),
@@ -13,7 +13,15 @@ export function createUiUpdater(browserWindow: BrowserWindow) {
       return;
     }
     const track = getTrackName(midiMessage);
-    const sketch = getSketch(midiMessage, portIndex);
-    browserWindow.webContents.send("ui-update", { type, track, sketch, value: midiMessage[1] });
+    if (isGlobal) {
+      // send global message to all sketches
+      for (let sketch: Sketch = 1; sketch <= 8; sketch++) {
+        browserWindow.webContents.send("ui-update", { type, track, sketch, value: midiMessage[1] });
+      }
+    } else {
+      // not a global message, send to currently active sketch
+      const sketch = getSketch(midiMessage, portIndex);
+      browserWindow.webContents.send("ui-update", { type, track, sketch, value: midiMessage[1] });
+    }
   };
 }


### PR DESCRIPTION
All MIDI messages except note on/off are now sent out to all sketches. This includes aftertouch, pitch bend and control change (CC).